### PR TITLE
Go CI version bump-up

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: 1.16.6
     
     - name: Setup dependencies
       run: go get -u github.com/kisielk/errcheck


### PR DESCRIPTION
Go CI version from 1.15 to 1.16.6

cc @JuanCalcagno416 