### PR TITLE
Good old unsafe counter to try Go Sync pkg

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Setup dependencies
       run: go get -u github.com/kisielk/errcheck
     
-    - name: Reports suspicious constructs based on higher level heuristics than the once used at compile time
+    - name: Reports suspicious constructs based on higher level heuristics than the ones used at compile time
       run: go vet ./...
 
     - name: Linter step - find unchecked errors

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,6 +20,9 @@ jobs:
     
     - name: Setup dependencies
       run: go get -u github.com/kisielk/errcheck
+    
+    - name: Reports suspicious constructs based on higher level heuristics than the once used at compile time
+      run: go vet ./...
 
     - name: Linter step - find unchecked errors
       run: errcheck ./...

--- a/sync/counter.go
+++ b/sync/counter.go
@@ -1,0 +1,24 @@
+package sync
+
+import "sync"
+
+//Counter is a synchronized counter, ready to support concurrent operations
+type Counter struct {
+	mu    sync.Mutex
+	value int
+}
+
+//NewCounter is the preferred way to initialise a counter
+func NewCounter() *Counter {
+	return &Counter{}
+}
+
+func (c *Counter) Inc() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.value++
+}
+
+func (c *Counter) Value() int {
+	return c.value
+}

--- a/sync/counter_test.go
+++ b/sync/counter_test.go
@@ -1,0 +1,74 @@
+package sync
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCounter(t *testing.T) {
+
+	assert := require.New(t)
+
+	t.Run("increment the counter 3 times leaves it at 3", func(t *testing.T) {
+		counter := NewCounter()
+		three := 3
+
+		for i := 0; i < three; i++ {
+			counter.Inc()
+		}
+
+		assert.Equal(three, counter.Value())
+	})
+
+	t.Run("it runs safely cuncurrently", func(t *testing.T) {
+		wantedCount := 1000
+		counter := NewCounter()
+
+		concurrentIncrement(counter, wantedCount)
+
+		assert.Equal(wantedCount, counter.Value())
+	})
+
+}
+
+func ExampleCounter() {
+	wantedCount := 1000
+	counter := NewCounter()
+
+	var wg sync.WaitGroup
+	wg.Add(wantedCount)
+
+	for i := 0; i < wantedCount; i++ {
+		go func() {
+			counter.Inc()
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+
+	fmt.Printf("%d", counter.Value())
+	/*Output: 1000*/
+}
+
+func BenchmarkCounter(b *testing.B) {
+	wantedCount := b.N
+	counter := NewCounter()
+
+	concurrentIncrement(counter, wantedCount)
+}
+
+func concurrentIncrement(counter *Counter, wantedCount int) {
+	var wg sync.WaitGroup
+	wg.Add(wantedCount)
+
+	for i := 0; i < wantedCount; i++ {
+		go func() {
+			counter.Inc()
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
An unsafe counter to prove a point on concurrency (BAU), this time using Go to fix it.

Plus: learn using `go vet`, to figure out I was copying a mutex instead of passing its reference when calling a method.

@JuanCalcagno416 